### PR TITLE
linkjs-ext/responder should pipe back error response body

### DIFF
--- a/lib/linkjs-ext/responder.js
+++ b/lib/linkjs-ext/responder.js
@@ -131,7 +131,9 @@
 			})
 			.except(function(err) {
 				console.log('response piping error from upstream:', err);
-				self.badGateway().end({ error:err });
+				var ctype = err.response.headers['content-type'] || 'text/plain';
+				var body = (ctype && err.response.body) ? err.response.body : '';
+				self.badGateway(ctype).end(body);
 			});
 	};
 


### PR DESCRIPTION
it's not useful to pipe back the full response, since the environment logging will catch it anyway

instead, pipe back the response body of the upstream, with its ctype
