### PR TITLE
client regions do not update the target context when targeting another region

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -308,8 +308,9 @@ var Environment = {};(function(exports) {
 
 	ClientRegion.prototype.__handleResponse = function(e, request, response) {
 		var requestTarget = this.__chooseRequestTarget(e, request);
-		if (requestTarget == this.element)
-			this.__updateContext(request, response);
+		var targetClient = Environment.getClientRegion(requestTarget.id);
+		if (targetClient)
+			targetClient.__updateContext(request, response);
 		CommonClient.handleResponse(requestTarget, this.element, response);
 		Environment.postProcessRegion(requestTarget);
 	};

--- a/lib/environment/client.js
+++ b/lib/environment/client.js
@@ -89,8 +89,9 @@
 
 	ClientRegion.prototype.__handleResponse = function(e, request, response) {
 		var requestTarget = this.__chooseRequestTarget(e, request);
-		if (requestTarget == this.element)
-			this.__updateContext(request, response);
+		var targetClient = Environment.getClientRegion(requestTarget.id);
+		if (targetClient)
+			targetClient.__updateContext(request, response);
 		CommonClient.handleResponse(requestTarget, this.element, response);
 		Environment.postProcessRegion(requestTarget);
 	};


### PR DESCRIPTION
a request generated from region A with a target of region B will not update any context

it should try to find a region at the target and set its context if possible
