### PR TITLE
<base> directives in docs are hardwired to grimwire.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
 	<head>
 		<title>Local 0.2.0</title>
-		<base href="http://grimwire.com/local/" />
 
 		<!-- security policies -->
 		<meta http-equiv="X-WebKit-CSP" content="frame-src 'none'; object-src 'none'; script-src 'self'"></meta>


### PR DESCRIPTION
this must have happened in the switch. Look into an alternative
