### PR TITLE
alter Link.dispatch to always route through Environment.dispatch

### DIFF
--- a/apps/env/reflector.js
+++ b/apps/env/reflector.js
@@ -176,7 +176,7 @@ ReflectorServer.prototype.$postServerEditor = function(request, response, match)
 			// load a new server in-place with the given source
 			Environment.addServer(domain, new Environment.WorkerServer({ script:request.body.source }));
 			// respond by piping a request to the new server
-			respond.pipe(Environment.dispatch(this, { method:'get', url:'httpl://'+domain, headers:{ accept:'text/html' }}));
+			respond.pipe(Link.dispatch({ method:'get', url:'httpl://'+domain, headers:{ accept:'text/html' }}, this));
 		} else {
 			// can't live-update environment servers (...yet?)
 			respond.respond([400, 'only worker servers can be live-updated']).end();

--- a/docs.js
+++ b/docs.js
@@ -3,9 +3,9 @@ var viewNav = document.getElementById('viewer-nav');
 viewNav.querySelector('a[href="'+(window.location.hash||'#readme.md')+'"]').parentNode.classList.add('active');
 
 // request wrapper
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.except(console.log.bind(console));
 	return response;
 });

--- a/docs/apps/building.md
+++ b/docs/apps/building.md
@@ -32,7 +32,7 @@ app.postMessage('loaded');
 
 Local revolves around HTTP, so a number of tools are provided to get the most out of it. This is a quick overview of the different APIs; more detail can be found in [Using LinkJS, the HTTP wrapper](../lib/linkjs.md).
 
-### Link.dispatch( <small>request</small> )
+### Link.dispatch( <small>request, [origin]</small> )
 
 Dispatches a request and returns a promise for the response. If the request URL's protocol is 'http' or 'https', it will issue an Ajax request. If it is 'httpl', it will issue a Web Worker or in-document request.
 
@@ -73,17 +73,9 @@ resPromise
 	});
 ```
 
-If you're writing in-document (environment) code, you might want to use `Environment.dispatch()` instead. This gives the environment an opportunity to examine and route the request.
+If you're writing in-document (environment) code, make sure to include the `origin` parameter (the second parameter). This is not necessary in the Worker, because `origin` is overwritten for safety.
 
- > Note: worker applications use `Link.dispatch`, but the request payload is delivered to the environment and dispatched via `Environment.dispatch`
-
-The usage is similar, except for an extra 'origin' parameter:
-
-```javascript
-Environment.dispatch(this, myrequest)
-	.then(success)
-	.except(failure);
-```
+ > Note: worker applications use `Link.dispatch`, but the request payload is delivered to the environment and dispatched after examination by the Environment's dispatch wrapper.
 
 ### Link.subscribe( <small>request/target url</small> )
 

--- a/docs/apps/dom_behaviors.md
+++ b/docs/apps/dom_behaviors.md
@@ -36,7 +36,7 @@ this.element.addEventListener('request', function(e) {
   }
 
   // issue request
-  promise(Environment.dispatch(self, request))
+  promise(Link.dispatch(request, self))
     .then(function(res) {
       // success, send back to common client
       res.on('end', function() {

--- a/docs/env/document_servers.md
+++ b/docs/env/document_servers.md
@@ -32,7 +32,7 @@ You may also wish to override `terminate()` if you wish to add deconstruction be
 
 Local revolves around HTTP, so a number of tools are provided to get the most out of it. This is a quick overview of the different APIs; more detail can be found in [Using LinkJS, the HTTP wrapper](../lib/linkjs.md).
 
-### Link.dispatch( <small>request</small> )
+### Link.dispatch( <small>request, [origin]</small> )
 
 Dispatches a request and returns a promise for the response. If the request URL's protocol is 'http' or 'https', it will issue an Ajax request. If it is 'httpl', it will issue a Web Worker or in-document request.
 
@@ -49,7 +49,7 @@ var resPromise = Link.dispatch({
 	body:requestPayload,
 	stream:false // do I want the response streamed? default false
 	             // (used for server-sent events)
-});
+}, this);
 ```
 
 Like much of Local's code, `dispatch` uses promises to handle async. If you're not familiar with promises, [have a look at the library's documentation](../lib/promises.md). `dispatch` returns a promise which is fulfilled if the response status is >= 200 && < 400, or rejected if >= 400.
@@ -71,18 +71,6 @@ resPromise
 		// => { status:404, reason:'not found', ...}
 		return err;
 	});
-```
-
-If you're writing in-document (environment) code, you might want to use `Environment.dispatch()` instead. This gives the environment an opportunity to examine and route the request.
-
- > Note: worker applications use `Link.dispatch`, but the request payload is delivered to the environment and dispatched via `Environment.dispatch`
-
-The usage is similar, except for an extra 'origin' parameter:
-
-```javascript
-Environment.dispatch(this, myrequest)
-	.then(success)
-	.except(failure);
 ```
 
 ### Link.subscribe( <small>request/target url</small> )

--- a/docs/examples/docs.md
+++ b/docs/examples/docs.md
@@ -21,7 +21,7 @@ function logError(err) {
 
 // request wrapper
 var currentHash = window.location.hash;
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 
 	var urld = Link.parseUri(request);
 	var newHash = '#' + urld.path.slice(1);
@@ -31,7 +31,7 @@ Environment.setDispatchHandler(function(origin, request) {
 	}
 
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.except(logError);
 	return response;
 });

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,7 +6,7 @@ pfraze 2013
 
 ## Overview
 
-Index.html is a small showcase of Local's primary features. It uses the environment reflector server (env/reflector.js) to give applications the tools to modify themselves, and the `Environment.dispatch` wrapper to log traffic to the UI.
+Index.html is a small showcase of Local's primary features. It uses the environment reflector server (env/reflector.js) to give applications the tools to modify themselves, and the `Link.dispatch` wrapper to log traffic to the UI.
 
 
 ## index.js
@@ -25,7 +25,7 @@ function logError(err) {
 
 // request wrapper
 var reqLog = new Link.Navigator('httpl://request-log.util');
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 	// make any connectivity / permissions decisions here
 
 	// pass on to the request log
@@ -39,7 +39,7 @@ Environment.setDispatchHandler(function(origin, request) {
 	}
 
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.except(logError);
 	return response;
 });

--- a/docs/examples/profile.md
+++ b/docs/examples/profile.md
@@ -31,7 +31,7 @@ function logError(err, request) {
 }
 
 // request wrapper
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 	// make any connectivity / permissions decisions here
 	var urld = Link.parseUri(request);
 
@@ -41,7 +41,7 @@ Environment.setDispatchHandler(function(origin, request) {
 	}
 
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.except(logError, request);
 	return response;
 });

--- a/docs/examples/reflector.md
+++ b/docs/examples/reflector.md
@@ -188,7 +188,7 @@ ReflectorServer.prototype.$postServerEditor = function(request, response, match)
 			// load a new server in-place with the given source
 			Environment.addServer(domain, new Environment.WorkerServer({ script:request.body.source }));
 			// respond by piping a request to the new server
-			respond.pipe(Environment.dispatch(this, { method:'get', url:'httpl://'+domain, headers:{ accept:'text/html' }}));
+			respond.pipe(Link.dispatch({ method:'get', url:'httpl://'+domain, headers:{ accept:'text/html' }}, this));
 		} else {
 			// can't live-update environment servers (...yet?)
 			respond.respond([400, 'only worker servers can be live-updated']).end();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 // request wrapper
 var reqLog = new Link.Navigator('httpl://request-log.util');
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 	// make any connectivity / permissions decisions here
 
 	// pass on to the request log
@@ -14,7 +14,7 @@ Environment.setDispatchHandler(function(origin, request) {
 	}
 
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.then(console.log.bind(console), request);
 	response.except(console.log.bind(console), request);
 	return response;

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -123,7 +123,7 @@ var Environment = {};(function(exports) {
 
 			// request from host
 			var jsRequest = { method:'get', url:scriptUrl, headers:{ accept:'application/javascript' }};
-			Environment.dispatch(requester, jsRequest)
+			Link.dispatch(jsRequest, requester)
 				.then(function(res) {
 					res.on('end', function() {
 						scriptPromise.fulfill(res.body);
@@ -166,7 +166,7 @@ var Environment = {};(function(exports) {
 		};
 
 		// execute the request
-		promise(this.environment.dispatch(this, message.data))
+		promise(Link.dispatch(message.data, this))
 			.then(handleResponse)
 			.except(handleErrors);
 	};
@@ -265,7 +265,7 @@ var Environment = {};(function(exports) {
 
 		var self = this;
 		this.__prepareRequest(request);
-		promise(Environment.dispatch(this, request))
+		promise(Link.dispatch(request, this))
 			.then(function(response) {
 				self.__handleResponse(e, request, response);
 			})
@@ -390,11 +390,13 @@ var Environment = {};(function(exports) {
 
 	exports.getClientRegion = function(id) { return Environment.clientRegions[id]; };
 
-	// dispatch wrapper
-	// - used by all WorkerServers, may be used elsewhere as desired
-	// - override this to control request permissions / sessions / etc
-	exports.dispatch = function(origin, req) {
-		var res = this.__dispatch(origin, req);
+	// dispatch monkeypatch
+	// - allows the environment to control request permissions / sessions / etc
+	// - adds the `origin` parameter, which is the object responsible for the request
+	var envDispatchWrapper;
+	var orgLinkDispatchFn = Link.dispatch;
+	Link.dispatch = function(req, origin) {
+		var res = envDispatchWrapper.call(this, req, origin, orgLinkDispatchFn);
 		if (res instanceof Promise) { return res; }
 
 		// make sure we respond with a valid client response
@@ -420,11 +422,11 @@ var Environment = {};(function(exports) {
 		}
 		return p;
 	};
-	exports.__dispatch = function(origin, req) {
-		return Link.dispatch(req);
+	envDispatchWrapper = function(req, origin, dispatch) {
+		return dispatch(req);
 	};
-	exports.setDispatchHandler = function(fn) {
-		this.__dispatch = fn;
+	exports.setDispatchWrapper = function(fn) {
+		envDispatchWrapper = fn;
 	};
 
 	// response html post-process

--- a/lib/environment/client.js
+++ b/lib/environment/client.js
@@ -46,7 +46,7 @@
 
 		var self = this;
 		this.__prepareRequest(request);
-		promise(Environment.dispatch(this, request))
+		promise(Link.dispatch(request, this))
 			.then(function(response) {
 				self.__handleResponse(e, request, response);
 			})

--- a/lib/environment/environment.js
+++ b/lib/environment/environment.js
@@ -64,11 +64,13 @@
 
 	exports.getClientRegion = function(id) { return Environment.clientRegions[id]; };
 
-	// dispatch wrapper
-	// - used by all WorkerServers, may be used elsewhere as desired
-	// - override this to control request permissions / sessions / etc
-	exports.dispatch = function(origin, req) {
-		var res = this.__dispatch(origin, req);
+	// dispatch monkeypatch
+	// - allows the environment to control request permissions / sessions / etc
+	// - adds the `origin` parameter, which is the object responsible for the request
+	var envDispatchWrapper;
+	var orgLinkDispatchFn = Link.dispatch;
+	Link.dispatch = function(req, origin) {
+		var res = envDispatchWrapper.call(this, req, origin, orgLinkDispatchFn);
 		if (res instanceof Promise) { return res; }
 
 		// make sure we respond with a valid client response
@@ -94,11 +96,11 @@
 		}
 		return p;
 	};
-	exports.__dispatch = function(origin, req) {
-		return Link.dispatch(req);
+	envDispatchWrapper = function(req, origin, dispatch) {
+		return dispatch(req);
 	};
-	exports.setDispatchHandler = function(fn) {
-		this.__dispatch = fn;
+	exports.setDispatchWrapper = function(fn) {
+		envDispatchWrapper = fn;
 	};
 
 	// response html post-process

--- a/lib/environment/server.js
+++ b/lib/environment/server.js
@@ -120,7 +120,7 @@
 
 			// request from host
 			var jsRequest = { method:'get', url:scriptUrl, headers:{ accept:'application/javascript' }};
-			Environment.dispatch(requester, jsRequest)
+			Link.dispatch(jsRequest, requester)
 				.then(function(res) {
 					res.on('end', function() {
 						scriptPromise.fulfill(res.body);
@@ -163,7 +163,7 @@
 		};
 
 		// execute the request
-		promise(this.environment.dispatch(this, message.data))
+		promise(Link.dispatch(message.data, this))
 			.then(handleResponse)
 			.except(handleErrors);
 	};

--- a/lib/link.js
+++ b/lib/link.js
@@ -601,7 +601,10 @@ if (typeof define !== "undefined") {
 	// custom error type, for use in promises
 	// EXPORTED
 	function ResponseError(response) {
-		this.message  = ''+response.status+': '+response.reason;
+		response = response || {};
+		response.headers = response.readers || {};
+
+		this.message = ''+response.status+': '+response.reason;
 		this.response = response;
 	}
 	ResponseError.prototype = new Error();
@@ -1270,7 +1273,7 @@ if (typeof define !== "undefined") {
 		if (!this.host) {
 			if (!this.url) { return null; }
 			var urld  = Link.parseUri(this.url);
-			this.host = (urld.protocol || 'http') + '://' + urld.authority;
+			this.host = (urld.protocol || 'http') + '://' + (urld.authority || window.location.host);
 		}
 		return this.host;
 	};

--- a/profile.js
+++ b/profile.js
@@ -8,7 +8,7 @@ function logError(err, request) {
 }
 
 // request wrapper
-Environment.setDispatchHandler(function(origin, request) {
+Environment.setDispatchWrapper(function(request, origin, dispatch) {
 	// make any connectivity / permissions decisions here
 	var urld = Link.parseUri(request);
 
@@ -18,7 +18,7 @@ Environment.setDispatchHandler(function(origin, request) {
 	}
 
 	// allow request
-	var response = Link.dispatch(request);
+	var response = dispatch(request);
 	response.except(logError, request);
 	return response;
 });


### PR DESCRIPTION
currently, Environment.dispatch wraps Link.dispatch, meaning the environment's traffic intermediary can be avoided. This is fine for WorkerServers, which don't have control over the choice. However, it's difficult to remember the difference when writing environments, and any request generator built on Link (such as the navigator) doesn't know to use Environment.dispatch
