### PR TITLE
disable subworkers in applications

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -70,11 +70,12 @@ var Environment = {};(function(exports) {
 	}
 	WorkerServer.prototype = Object.create(Server.prototype);
 
-	// runs LinkAP initialization for a worker thread
+	// runs Local initialization for a worker thread
 	// - called when the myhouse worker_bootstrap has finished loading
 	WorkerServer.prototype.onWorkerReady = function(message) {
-		// disable ajax in the worker
+		// disable dangerous APIs
 		this.worker.nullify('XMLHttpRequest');
+		this.worker.nullify('Worker');
 		// send config to the worker thread
 		this.worker.postReply(message, this.config);
 		this.worker.importScripts('worker_httpl.js');

--- a/lib/environment/server.js
+++ b/lib/environment/server.js
@@ -67,11 +67,12 @@
 	}
 	WorkerServer.prototype = Object.create(Server.prototype);
 
-	// runs LinkAP initialization for a worker thread
+	// runs Local initialization for a worker thread
 	// - called when the myhouse worker_bootstrap has finished loading
 	WorkerServer.prototype.onWorkerReady = function(message) {
-		// disable ajax in the worker
+		// disable dangerous APIs
 		this.worker.nullify('XMLHttpRequest');
+		this.worker.nullify('Worker');
 		// send config to the worker thread
 		this.worker.postReply(message, this.config);
 		this.worker.importScripts('worker_httpl.js');


### PR DESCRIPTION
by creating a subworker, an application could gain full access to the worker API, which would include XHR
