### PR TITLE
request targets need a secure default

### DIFF
--- a/lib/environment.js
+++ b/lib/environment.js
@@ -230,8 +230,9 @@ var Environment = {};(function(exports) {
 			url   : '',
 			urld  : {},
 			links : [],
-			type  : ''
+			type  : '' // content type of the response
 		};
+		this.featureRights = {}; // feature enable/disable based on security
 
 		this.element = document.getElementById(id);
 		if (!this.element) { throw "ClientRegion target element not found"; }
@@ -253,16 +254,23 @@ var Environment = {};(function(exports) {
 		this.element.removeEventListener('request', this.listenerFn);
 	};
 
+	ClientRegion.prototype.addRight = function(feature, options) {
+		this.featureRights[feature] = options || true;
+	};
+
+	ClientRegion.prototype.removeRight = function(feature) {
+		delete this.featureRights[feature];
+	};
+
+	ClientRegion.prototype.hasRights = function(feature) {
+		return this.featureRights[feature];
+	};
+
 	function handleRequest(e) {
 		e.preventDefault();
 		e.stopPropagation();
 
 		var request = e.detail;
-
-		var url = request.url || request.host;
-		// if (RegExp('^(http|httpl|https)://','i').test(url) === false) {
-		// 	return;
-		// }
 
 		var self = this;
 		this.__prepareRequest(request);
@@ -320,7 +328,10 @@ var Environment = {};(function(exports) {
 		if (e.target.tagName == 'OUTPUT') {
 			return e.target;
 		} else {
-			return document.getElementById(request.target) || this.element;
+			if (this.hasRights('element targeting'))
+				return document.getElementById(request.target) || this.element;
+			else
+				return this.element;
 		}
 	};
 

--- a/lib/environment/client.js
+++ b/lib/environment/client.js
@@ -10,8 +10,9 @@
 			url   : '',
 			urld  : {},
 			links : [],
-			type  : ''
+			type  : '' // content type of the response
 		};
+		this.featureRights = {}; // feature enable/disable based on security
 
 		this.element = document.getElementById(id);
 		if (!this.element) { throw "ClientRegion target element not found"; }
@@ -33,16 +34,23 @@
 		this.element.removeEventListener('request', this.listenerFn);
 	};
 
+	ClientRegion.prototype.addRight = function(feature, options) {
+		this.featureRights[feature] = options || true;
+	};
+
+	ClientRegion.prototype.removeRight = function(feature) {
+		delete this.featureRights[feature];
+	};
+
+	ClientRegion.prototype.hasRights = function(feature) {
+		return this.featureRights[feature];
+	};
+
 	function handleRequest(e) {
 		e.preventDefault();
 		e.stopPropagation();
 
 		var request = e.detail;
-
-		var url = request.url || request.host;
-		// if (RegExp('^(http|httpl|https)://','i').test(url) === false) {
-		// 	return;
-		// }
 
 		var self = this;
 		this.__prepareRequest(request);
@@ -100,7 +108,10 @@
 		if (e.target.tagName == 'OUTPUT') {
 			return e.target;
 		} else {
-			return document.getElementById(request.target) || this.element;
+			if (this.hasRights('element targeting'))
+				return document.getElementById(request.target) || this.element;
+			else
+				return this.element;
 		}
 	};
 


### PR DESCRIPTION
currently, the standard behavior for request targets enables the application to target any element id it wants. This breaks with the overall philosophy of secure defaults

this behavior should not be allowed unless the environment enables it. This can be done either with the current option -- subtyping ClientRegion -- or with a hook like the dispatch handler
