### PR TITLE
Add the "application/html-deltas+json" response type behaviors

### DIFF
--- a/lib/local.js
+++ b/lib/local.js
@@ -2876,22 +2876,69 @@ var CommonClient = {};
 	// replaces the targetElem's innerHTML with the response payload
 	function renderResponse(targetElem, containerElem, response) {
 
-		var html = '';
 		if (response.body) {
-			if (/text\/html/.test(response.headers['content-type'])) {
-				html = response.body.toString();
+			var type = response.headers['content-type'];
+			if (/application\/html\-deltas\+json/.test(type)) {
+				if (typeof response.body != 'object')
+					console.log('Improperly-formed application/html-deltas+json object', response);
+				else {
+					for (var op in response.body)
+						renderHtmlDeltas(op, response.body[op], targetElem, containerElem);
+				}
 			} else {
-				// escape non-html so that it can render correctly
-				if (typeof response.body == 'string')
-					html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-				else
-					html = JSON.stringify(response.body);
+				var html = '';
+				if (/text\/html/.test(type))
+					html = response.body.toString();
+				else {
+					// escape non-html so that it can render correctly
+					if (typeof response.body == 'string')
+						html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					else
+						html = JSON.stringify(response.body);
+				}
+				targetElem.innerHTML = html;
 			}
 		}
 
-		targetElem.innerHTML = html;
 		bindAttrEvents(targetElem, containerElem);
 		subscribeElements(targetElem, containerElem);
+	}
+
+	function renderHtmlDeltas(op, deltas, targetElem, containerElem) {
+		if (typeof deltas != 'object')
+			return;
+		for (var selector in deltas) {
+			var elems = containerElem.querySelectorAll(selector);
+			var htmlDeltaAddClass = function(cls) { elems[i].classList.add(cls); };
+			var htmlDeltaRemoveClass = function(cls) { elems[i].classList.remove(cls); };
+			var htmlDeltaToggleClass = function(cls) { elems[i].classList.toggle(cls); };
+			for (var i = 0, ii=elems.length; i < ii; i++) {
+				if (!elems[i]) continue;
+				switch (op) {
+					case 'replace':
+						elems[i].innerHTML = deltas[selector];
+						break;
+					case 'append':
+						elems[i].innerHTML = elems[i].innerHTML + deltas[selector];
+						break;
+					case 'prepend':
+						elems[i].innerHTML = deltas[selector] + elems[i].innerHTML;
+						break;
+					case 'addClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaAddClass);
+						break;
+					case 'removeClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaRemoveClass);
+						break;
+					case 'toggleClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaToggleClass);
+						break;
+				}
+			}
+		}
 	}
 
 	exports.handleResponse = CommonClient__handleResponse;

--- a/lib/local.min.js
+++ b/lib/local.min.js
@@ -2876,22 +2876,69 @@ var CommonClient = {};
 	// replaces the targetElem's innerHTML with the response payload
 	function renderResponse(targetElem, containerElem, response) {
 
-		var html = '';
 		if (response.body) {
-			if (/text\/html/.test(response.headers['content-type'])) {
-				html = response.body.toString();
+			var type = response.headers['content-type'];
+			if (/application\/html\-deltas\+json/.test(type)) {
+				if (typeof response.body != 'object')
+					console.log('Improperly-formed application/html-deltas+json object', response);
+				else {
+					for (var op in response.body)
+						renderHtmlDeltas(op, response.body[op], targetElem, containerElem);
+				}
 			} else {
-				// escape non-html so that it can render correctly
-				if (typeof response.body == 'string')
-					html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-				else
-					html = JSON.stringify(response.body);
+				var html = '';
+				if (/text\/html/.test(type))
+					html = response.body.toString();
+				else {
+					// escape non-html so that it can render correctly
+					if (typeof response.body == 'string')
+						html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					else
+						html = JSON.stringify(response.body);
+				}
+				targetElem.innerHTML = html;
 			}
 		}
 
-		targetElem.innerHTML = html;
 		bindAttrEvents(targetElem, containerElem);
 		subscribeElements(targetElem, containerElem);
+	}
+
+	function renderHtmlDeltas(op, deltas, targetElem, containerElem) {
+		if (typeof deltas != 'object')
+			return;
+		for (var selector in deltas) {
+			var elems = containerElem.querySelectorAll(selector);
+			var htmlDeltaAddClass = function(cls) { elems[i].classList.add(cls); };
+			var htmlDeltaRemoveClass = function(cls) { elems[i].classList.remove(cls); };
+			var htmlDeltaToggleClass = function(cls) { elems[i].classList.toggle(cls); };
+			for (var i = 0, ii=elems.length; i < ii; i++) {
+				if (!elems[i]) continue;
+				switch (op) {
+					case 'replace':
+						elems[i].innerHTML = deltas[selector];
+						break;
+					case 'append':
+						elems[i].innerHTML = elems[i].innerHTML + deltas[selector];
+						break;
+					case 'prepend':
+						elems[i].innerHTML = deltas[selector] + elems[i].innerHTML;
+						break;
+					case 'addClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaAddClass);
+						break;
+					case 'removeClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaRemoveClass);
+						break;
+					case 'toggleClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaToggleClass);
+						break;
+				}
+			}
+		}
 	}
 
 	exports.handleResponse = CommonClient__handleResponse;

--- a/lib/local/common-client.js
+++ b/lib/local/common-client.js
@@ -153,22 +153,69 @@ var CommonClient = {};
 	// replaces the targetElem's innerHTML with the response payload
 	function renderResponse(targetElem, containerElem, response) {
 
-		var html = '';
 		if (response.body) {
-			if (/text\/html/.test(response.headers['content-type'])) {
-				html = response.body.toString();
+			var type = response.headers['content-type'];
+			if (/application\/html\-deltas\+json/.test(type)) {
+				if (typeof response.body != 'object')
+					console.log('Improperly-formed application/html-deltas+json object', response);
+				else {
+					for (var op in response.body)
+						renderHtmlDeltas(op, response.body[op], targetElem, containerElem);
+				}
 			} else {
-				// escape non-html so that it can render correctly
-				if (typeof response.body == 'string')
-					html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-				else
-					html = JSON.stringify(response.body);
+				var html = '';
+				if (/text\/html/.test(type))
+					html = response.body.toString();
+				else {
+					// escape non-html so that it can render correctly
+					if (typeof response.body == 'string')
+						html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					else
+						html = JSON.stringify(response.body);
+				}
+				targetElem.innerHTML = html;
 			}
 		}
 
-		targetElem.innerHTML = html;
 		bindAttrEvents(targetElem, containerElem);
 		subscribeElements(targetElem, containerElem);
+	}
+
+	function renderHtmlDeltas(op, deltas, targetElem, containerElem) {
+		if (typeof deltas != 'object')
+			return;
+		for (var selector in deltas) {
+			var elems = containerElem.querySelectorAll(selector);
+			var htmlDeltaAddClass = function(cls) { elems[i].classList.add(cls); };
+			var htmlDeltaRemoveClass = function(cls) { elems[i].classList.remove(cls); };
+			var htmlDeltaToggleClass = function(cls) { elems[i].classList.toggle(cls); };
+			for (var i = 0, ii=elems.length; i < ii; i++) {
+				if (!elems[i]) continue;
+				switch (op) {
+					case 'replace':
+						elems[i].innerHTML = deltas[selector];
+						break;
+					case 'append':
+						elems[i].innerHTML = elems[i].innerHTML + deltas[selector];
+						break;
+					case 'prepend':
+						elems[i].innerHTML = deltas[selector] + elems[i].innerHTML;
+						break;
+					case 'addClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaAddClass);
+						break;
+					case 'removeClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaRemoveClass);
+						break;
+					case 'toggleClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaToggleClass);
+						break;
+				}
+			}
+		}
 	}
 
 	exports.handleResponse = CommonClient__handleResponse;

--- a/src/common-client/common-client.js
+++ b/src/common-client/common-client.js
@@ -153,22 +153,69 @@ var CommonClient = {};
 	// replaces the targetElem's innerHTML with the response payload
 	function renderResponse(targetElem, containerElem, response) {
 
-		var html = '';
 		if (response.body) {
-			if (/text\/html/.test(response.headers['content-type'])) {
-				html = response.body.toString();
+			var type = response.headers['content-type'];
+			if (/application\/html\-deltas\+json/.test(type)) {
+				if (typeof response.body != 'object')
+					console.log('Improperly-formed application/html-deltas+json object', response);
+				else {
+					for (var op in response.body)
+						renderHtmlDeltas(op, response.body[op], targetElem, containerElem);
+				}
 			} else {
-				// escape non-html so that it can render correctly
-				if (typeof response.body == 'string')
-					html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-				else
-					html = JSON.stringify(response.body);
+				var html = '';
+				if (/text\/html/.test(type))
+					html = response.body.toString();
+				else {
+					// escape non-html so that it can render correctly
+					if (typeof response.body == 'string')
+						html = response.body.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+					else
+						html = JSON.stringify(response.body);
+				}
+				targetElem.innerHTML = html;
 			}
 		}
 
-		targetElem.innerHTML = html;
 		bindAttrEvents(targetElem, containerElem);
 		subscribeElements(targetElem, containerElem);
+	}
+
+	function renderHtmlDeltas(op, deltas, targetElem, containerElem) {
+		if (typeof deltas != 'object')
+			return;
+		for (var selector in deltas) {
+			var elems = containerElem.querySelectorAll(selector);
+			var htmlDeltaAddClass = function(cls) { elems[i].classList.add(cls); };
+			var htmlDeltaRemoveClass = function(cls) { elems[i].classList.remove(cls); };
+			var htmlDeltaToggleClass = function(cls) { elems[i].classList.toggle(cls); };
+			for (var i = 0, ii=elems.length; i < ii; i++) {
+				if (!elems[i]) continue;
+				switch (op) {
+					case 'replace':
+						elems[i].innerHTML = deltas[selector];
+						break;
+					case 'append':
+						elems[i].innerHTML = elems[i].innerHTML + deltas[selector];
+						break;
+					case 'prepend':
+						elems[i].innerHTML = deltas[selector] + elems[i].innerHTML;
+						break;
+					case 'addClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaAddClass);
+						break;
+					case 'removeClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaRemoveClass);
+						break;
+					case 'toggleClass':
+						if (elems[i].classList)
+							deltas[selector].split(' ').forEach(htmlDeltaToggleClass);
+						break;
+				}
+			}
+		}
 	}
 
 	exports.handleResponse = CommonClient__handleResponse;

--- a/test/common-client.html
+++ b/test/common-client.html
@@ -51,8 +51,17 @@
 				<input id="form2submit1" type="submit" />
 			</form>
 			<div id="target1"></div>
-			<div id="target2"></div>
+			<div id="target2">
+				<div class="replace-me1">original</div>
+				<div class="replace-me2">original</div>
+				<div class="append-me">original</div>
+				<div class="prepend-me">original</div>
+				<div class="addclass-me">original</div>
+				<div class="removeclass-me removed">original</div>
+				<div class="toggleclass-me toggle1">original</div>
+			</div>
 			<div id="target3"></div>
+			<div id="target4"></div>
 		</div>
 
 		<script src="../lib/local.dev.js"></script>

--- a/test/common-client/browser.js
+++ b/test/common-client/browser.js
@@ -150,7 +150,7 @@ wait(function () { return done; });
 }
 */
 
-// test: response interpretation
+// test: html response interpretation
 done = false;
 startTime = Date.now();
 
@@ -199,16 +199,79 @@ wait(function () { return done; });
 <h1>Response 1</h1>
 */
 
-// test: attr event binding
+// test: html-deltas response interpretation
 done = false;
 startTime = Date.now();
 
 function request2Handler(e) {
+  // fixture response
+  var response = { status:200, reason:'Ok', headers:{ 'content-type':'application/html-deltas+json' }, body: {
+    replace: { '.replace-me1':'replaced', '.replace-me2':'replaced' },
+    append: { '.append-me':'appended' },
+    prepend: { '.prepend-me':'prepended' },
+    addClass: { '.addclass-me':'added' },
+    removeClass: { '.removeclass-me':'removed' },
+    toggleClass: { '.toggleclass-me':'toggle1 toggle2' }
+  }};
+
+  // pass on to common client
+  CommonClient.handleResponse(
+    document.getElementById('target2'),
+    document.getElementById('testarea'),
+    response
+  );
+}
+
+mainDiv.addEventListener('request', request2Handler);
+
+var clickEvent = document.createEvent('MouseEvents');
+clickEvent.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+document.getElementById('form1submit2').dispatchEvent(clickEvent);
+print(document.getElementById('target2').innerHTML);
+
+mainDiv.removeEventListener('request', request2Handler);
+
+wait(function () { return done; });
+
+/* =>
+{
+  body: {
+    check1: ["b"],
+    form1submit2: "form1submit2 value",
+    radio1: "radio1 value1",
+    radio2: "radio2 value2",
+    select1: "select1 value1",
+    select2: "select2 value2",
+    select3: "select3 value3",
+    text1: "text1 value",
+    text2: "text2 value",
+    textarea1: "textarea 1 value"
+  },
+  headers: {"content-type": "application/json"},
+  method: "patch",
+  target: "target1",
+  url: "http://www.form1.com/foobar"
+}
+
+<div class="replace-me1">replaced</div>
+<div class="replace-me2">replaced</div>
+<div class="append-me">originalappended</div>
+<div class="prepend-me">prependedoriginal</div>
+<div class="addclass-me added">original</div>
+<div class="removeclass-me">original</div>
+<div class="toggleclass-me toggle2">original</div>
+*/
+
+// test: attr event binding
+done = false;
+startTime = Date.now();
+
+function request3Handler(e) {
 	// fixture response
 	var response = {
 		status:200, reason:'Ok', headers:{ 'content-type':'text/html' },
 		body:[
-			'<form method="get" action="http://www.form3.com" target="target2" onchange="delete">',
+			'<form method="get" action="http://www.form3.com" target="target3" onchange="delete">',
 			'<input type="text" name="text1" onchange="patch" />',
 			'<input type="text" name="text2" onkeyup="put" formaction="http://www.form3.com/foobar" />',
 			'<fieldset formaction="http://www.form3.com/foobaz" onchange="patch">',
@@ -222,25 +285,25 @@ function request2Handler(e) {
 
 	// pass on to common client
 	CommonClient.handleResponse(
-		document.getElementById('target2'),
+		document.getElementById('target3'),
 		document.getElementById('testarea'),
 		response
 	);
 }
 
-mainDiv.addEventListener('request', request2Handler);
+mainDiv.addEventListener('request', request3Handler);
 
 var clickEvent = document.createEvent('MouseEvents');
 clickEvent.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
 document.getElementById('form1submit2').dispatchEvent(clickEvent);
-print(document.getElementById('target2').innerHTML);
+print(document.getElementById('target3').innerHTML);
 
-mainDiv.removeEventListener('request', request2Handler);
+mainDiv.removeEventListener('request', request3Handler);
 
 wait(function () { return done; });
 done = false;
 
-var region = document.getElementById('target2');
+var region = document.getElementById('target3');
 
 var changeEvent = document.createEvent('UIEvents');
 changeEvent.initUIEvent('change', true, true, window, {});
@@ -300,33 +363,33 @@ wait(function () { return done; });
   target: "target1",
   url: "http://www.form1.com/foobar"
 }
-<form method="get" action="http://www.form3.com" target="target2"><input type="text" name="text1"><input type="text" name="text2" formaction="http://www.form3.com/foobar"><fieldset formaction="http://www.form3.com/foobaz"><input type="text" name="text3"><input type="text" name="text4" formenctype="application/json"></fieldset><input type="text" name="text5"></form>
+<form method="get" action="http://www.form3.com" target="target3"><input type="text" name="text1"><input type="text" name="text2" formaction="http://www.form3.com/foobar"><fieldset formaction="http://www.form3.com/foobaz"><input type="text" name="text3"><input type="text" name="text4" formenctype="application/json"></fieldset><input type="text" name="text5"></form>
 {
   body: {text1: "foobar"},
   headers: {"content-type": "application/x-www-form-urlencoded"},
   method: "patch",
-  target: "target2",
+  target: "target3",
   url: "http://www.form3.com"
 }
 {
   body: {text2: "foobaz"},
   headers: {"content-type": "application/x-www-form-urlencoded"},
   method: "put",
-  target: "target2",
+  target: "target3",
   url: "http://www.form3.com/foobar"
 }
 {
   body: {text3: "foobleh", text4: "foobot"},
   headers: {"content-type": "application/x-www-form-urlencoded"},
   method: "patch",
-  target: "target2",
+  target: "target3",
   url: "http://www.form3.com/foobaz"
 }
 {
   body: {text4: "foobot"},
   headers: {"content-type": "application/json"},
   method: "patch",
-  target: "target2",
+  target: "target3",
   url: "http://www.form3.com/foobaz"
 }
 {
@@ -339,7 +402,7 @@ wait(function () { return done; });
   },
   headers: {"content-type": "application/x-www-form-urlencoded"},
   method: "delete",
-  target: "target2",
+  target: "target3",
   url: "http://www.form3.com"
 }
 */
@@ -361,7 +424,7 @@ Link.registerLocal('event-emitter.com', function(request, response) {
 });
 
 CommonClient.handleResponse(
-	document.getElementById('target3'),
+	document.getElementById('target4'),
 	document.getElementById('testarea'),
 	{ status:200, reason:'Ok', headers: { 'content-type':'text/html' },
 		body:[
@@ -385,11 +448,13 @@ streams[1].write({ event:'update', data:['irrelevant']});
 {
   headers: {accept: "text/html"},
   method: "get",
+  target: "_elem",
   url: "httpl://event-emitter.com"
 }
 {
   headers: {accept: "text/html"},
   method: "get",
+  target: "_elem",
   url: "httpl://event-emitter.com"
 }
 */


### PR DESCRIPTION
_From the documentation:_

Occasionally, server responses need to make targeted updates to the UI, in order to avoid losing the state of form elements. This is accomplished by responding to an html request with the "application/html-delta+json" type.

``` html
//...
respond.ok('application/html-delta+json').end({
  replace: {
    '.messages': buildMessagesHTML(),
    '.toolbar .last-update': '<em>Connected at '+getDateString()+'</em>'
  },
  addClass: {
    '.toolbar .connect': 'disabled'
  },
  removeClass: {
    '.toolbar .disconnect': 'disabled'
  }
});
//...
```

The schema of an html-delta follows the form of { operation: { selector: content } }. The list of supported operations is:
- replace: set the selector target's innerHTML to the content
- append: add the content to the end of the selector target's innerHTML
- prepend: add the content to the beginning of the selector target's innerHTML
- addClass: add the content to the selector target's class
- removeClass: remove the content from the selector target's class
- toggleClass: toggle the content in the selector target's class

Additional tips:
- The Link.Responder class (used above) aliases "html-deltas" to "application/html-deltas+json", allowing you to write respond.ok("html-deltas").
